### PR TITLE
fix(udc): Switch to blueprint chromium webview module

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -6,8 +6,7 @@
   <project path="device/lineage/car" name="LineageOS/android_device_lineage_car" />
   <project path="external/bash" name="LineageOS/android_external_bash" />
   <project path="external/chromium-webview/patches" name="LineageOS/android_external_chromium-webview_patches" groups="pdk" revision="main" >
-    <linkfile src="Android.mk" dest="external/chromium-webview/Android.mk" />
-    <linkfile src="CleanSpec.mk" dest="external/chromium-webview/CleanSpec.mk" />
+    <linkfile src="os_pickup.bp" dest="external/chromium-webview/Android.bp" />
     <linkfile src="README" dest="external/chromium-webview/README" />
   </project>
   <project path="external/chromium-webview/prebuilt/arm" name="LineageOS/android_external_chromium-webview_prebuilt_arm" groups="pdk" revision="main" />


### PR DESCRIPTION
I know that this is dropped but this is a simple change to keep A14 still buildable

Change-Id: I9ed58ed719401d9d5c1a381f761b0aabf89e0b11