### PR TITLE
manifest: fix AOSP remote fetch URL

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote  name="aosp"
-           fetch=".."
+           fetch="https://android.googlesource.com"
            review="https://android-review.googlesource.com/" />
   <default revision="refs/tags/android-17.0.0_r1"
            remote="aosp"


### PR DESCRIPTION
The cnb manifest defines the AOSP remote as fetch="..". Since Evolution-X/manifest is hosted on GitHub, repo resolves inherited AOSP projects like platform/art as:

https://github.com/platform/art

which does not exist.

Fix:
Change the aosp remote fetch to:

https://android.googlesource.com

I've tested it locally and it worked. 


Change-Id: I311a4cd0355ab5b8b53007a2ad7bdb622287a068